### PR TITLE
Show settings and toggle from quick pick

### DIFF
--- a/SettingsCycler/package.json
+++ b/SettingsCycler/package.json
@@ -52,7 +52,13 @@
           }
         }
       }
-    }
+    },
+    "commands": [
+        {
+            "command": "settings.cycle.show",
+            "title": "Show settings.cycle"
+        }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "tsc -p ./",

--- a/SettingsCycler/src/extension.ts
+++ b/SettingsCycler/src/extension.ts
@@ -1,5 +1,5 @@
 'use strict';
-import { ExtensionContext, workspace, window, commands as Commands, languages, WorkspaceConfiguration } from 'vscode';
+import { ExtensionContext, workspace, window, commands as Commands, languages, WorkspaceConfiguration, QuickPickItem } from 'vscode';
 
 const deepEqual = require('deep-equal')
 
@@ -30,17 +30,14 @@ function registerUtilityCommands() {
         const config = workspace.getConfiguration();
         const commands = workspace.getConfiguration('settings').get<Command[]>('cycle');
         window.showQuickPick(commands.reduce(function(o, c) {
-            o.push(`${c.setting} : ${ JSON.stringify(getCurrentSetting(c, config).value) }`)
+            o.push({ description: JSON.stringify(getCurrentSetting(c, config).value), label: c.setting})
             return o
-        },[])).then((selection:string) => {
+        }, [])).then((selection: QuickPickItem) => {
             if(selection) {
-                const setting = selection.split(' : ')
-                if(setting.length) {
-                    var command = commands.filter(cmd => {
-                        return cmd.setting == setting[0]
-                    })
-                    if(command.length) cycleSetting(command[0])
-                }
+                var command = commands.filter(cmd => {
+                    return cmd.setting == selection.label
+                })
+                if (command.length) cycleSetting(command[0])
             }
         })
     })


### PR DESCRIPTION
This does 2 things, I mainly started this so I could see quickly the settings for non obvious visual settings like `editor.formatOnPaste` or `editor.tabSize` so this gives the quick visual, but also allows you to execute the toggle once displayed, may be handy if you forget your shortcuts.

The title could be better, and I won't be offended if there is a better flow to achieve this, just let me know