### PR TITLE
Fix keybinding example in settings cycler readme.

### DIFF
--- a/SettingsCycler/README.md
+++ b/SettingsCycler/README.md
@@ -28,7 +28,7 @@ If you like to keep your settings files small, you can use keybindings.json to p
 ```json
 {
 	"key": "F4",
-	"command": "toggle",
+	"command": "settings.cycle",
 	"when": "editorTextFocus",
 	"args": {
 		"id": "zen", // must be unique


### PR DESCRIPTION
In the keybinding example in the readme, the command is listed as "toggle", not "settings.cycle" as it should be. I guess this was left over from the original toggle extension's readme.

I'm not sure why there's a change on the last line, they look identical to me. I used the github editor.